### PR TITLE
Template Fixes

### DIFF
--- a/backbone.tableview.coffee
+++ b/backbone.tableview.coffee
@@ -414,7 +414,7 @@ class Backbone.TableView.ButtonFilter extends Backbone.TableView.Filter
 class Backbone.TableView.ButtonGroupFilter extends Backbone.TableView.Filter
     template: _.template """
         <% _.each(options, function (el, i) { %>
-            <button class="btn <%= _.contains(init, el.value) ? "active" : "" %> <%= !_.isUndefined(el.className) ? el.className : "" %>" value="<%= el.value %>"><%= el.name %></button>
+            <button type="button" class="btn <%= _.contains(init, el.value) ? "active" : "" %> <%= !_.isUndefined(el.className) ? el.className : "" %>" value="<%= el.value %>"><%= el.name %></button>
         <% }) %>
     """
     className: "btn-group pull-left tableview-filterbox"
@@ -430,7 +430,7 @@ class Backbone.TableView.ButtonGroupFilter extends Backbone.TableView.Filter
 class Backbone.TableView.ButtonOptionFilter extends Backbone.TableView.Filter
     template: _.template """
         <% _.each(options, function (el, i) { %>
-            <button class="btn <%= init == el.value ? "active" : "" %>" value="<%= el.value %>"><%= el.name %></button>
+            <button type="button" class="btn <%= init == el.value ? "active" : "" %>" value="<%= el.value %>"><%= el.name %></button>
         <% }) %>
     """
     className: "btn-group pull-left tableview-filterbox"
@@ -446,7 +446,7 @@ class Backbone.TableView.DropdownFilter extends Backbone.TableView.Filter
     template: _.template """
         <select class="filter <%= filterClass %>">
             <% _.each(options, function (el, i) { %>
-                <option <%= init == el.value ? "selected='selected'" : "" %> value="<%= el.value %>"><%= el.name %></button>
+                <option <%= init == el.value ? "selected='selected'" : "" %> value="<%= el.value %>"><%= el.name %></option>
             <% }) %>
         </select>
     """


### PR DESCRIPTION
This fix is for html issues for filter templates.

When using a button option filter, clicking on the button was triggering a submit event to be fired. Because the html was within a form, the form was getting submitted accidentally. button type=button fixes this. 

The dropdown template html's option tag was also being closed with /button instead of /option, which messed up rendering somewhat.
